### PR TITLE
v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,18 @@
     — Finds whether the given variable is a [resource](https://www.php.net/types.resource) that has been closed.
   - [is_non_empty_string()](https://usephul.empaphy.org/packages/Types-Variables.html#function_is_non_empty_string)
     — Find whether a variable is a non-empty string.
+  - [is_negative_int()](https://usephul.empaphy.org/packages/Types-Variables.html#function_is_negative_int)
+    — Find whether a variable is an integer and less than zero.
+  - [is_non_negative_int()](https://usephul.empaphy.org/packages/Types-Variables.html#function_is_non_negative_int)
+    — Find whether a variable is an integer and not less than zero.
+  - [is_non_positive_int()](https://usephul.empaphy.org/packages/Types-Variables.html#function_is_non_positive_int)
+    — Find whether a variable is an integer and not greater than zero.
+  - [is_non_zero_int()](https://usephul.empaphy.org/packages/Types-Variables.html#function_is_non_zero_int)
+    — Find whether a variable is an integer and not zero.
+  - [is_number()](https://usephul.empaphy.org/packages/Types-Variables.html#function_is_number)
+    — Find whether a variable is a number (either an integer or a float).
+  - [is_positive_int()](https://usephul.empaphy.org/packages/Types-Variables.html#function_is_positive_int)
+    — Find whether a variable is an integer and greater than zero.
   - [is_zero()](https://usephul.empaphy.org/packages/Types-Variables.html#function_is_zero)
     — Finds whether the given number is (sufficiently close to) 0.
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@
 
 ### Variable handling Functions
 
-  - [is_closed_resource()](https://usephul.empaphy.org/packages/Types.html#function_is_closed_resource)
+  - [is_closed_resource()](https://usephul.empaphy.org/packages/Types-Variables.html#function_is_closed_resource)
     — Finds whether the given variable is a [resource](https://www.php.net/types.resource) that has been closed.
-  - [is_zero()](https://usephul.empaphy.org/packages/Types.html#function_is_zero)
+  - [is_non_empty_string()](https://usephul.empaphy.org/packages/Types-Variables.html#function_is_non_empty_string)
+    — Find whether a variable is a non-empty string.
+  - [is_zero()](https://usephul.empaphy.org/packages/Types-Variables.html#function_is_zero)
     — Finds whether the given number is (sufficiently close to) 0.
 
 ### Trait Functions

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
             "src/constants.php",
             "src/filesystem.php",
             "src/functions.php",
-            "src/other.php"
+            "src/other.php",
+            "src/var.php"
         ],
         "psr-4": {
             "empaphy\\usephul\\": "src/"

--- a/src/constants.php
+++ b/src/constants.php
@@ -15,8 +15,3 @@ namespace empaphy\usephul;
  * This mask matches every possible past and future PHP error level.
  */
 const E_EVERYTHING = 0x7FFFFFFF;
-
-/**
- * Default error tolerance.
- */
-const PHP_ZERO_TOLERANCE = 0.00000000001;

--- a/src/functions.php
+++ b/src/functions.php
@@ -39,39 +39,6 @@ function array_interchange(array $array, int|string $key1, int|string $key2): ar
 }
 
 /**
- * Finds whether the given variable is a
- * {@link https://www.php.net/types.resource resource} that has been closed.
- *
- * @package Types
- *
- * @template T
- *
- * @param  T  $value  The variable being evaluated.
- * @return (T is resource ? bool : false) Returns `true` if **value** is a
- *                                        <u>resource</u> variable that has been
- *                                        closed, `false` otherwise.
- */
-function is_closed_resource(mixed $value): bool
-{
-    return Type::ClosedResource->is($value);
-}
-
-/**
- * Finds whether the given number is (sufficiently close to) 0.
- *
- * @package Types
- *
- * @param  int|float   $value      The number being evaluated.
- * @param  float|null  $tolerance  Tolerance allowed when evaluating the number.
- * @return bool Returns <u>true</u> if **value** is (sufficiently close to) 0,
- *              <u>false</u> otherwise.
- */
-function is_zero(int | float $value, ?float $tolerance = PHP_ZERO_TOLERANCE): bool
-{
-    return 0 === $value || 0.0 === $value || (null !== $tolerance && \abs($value) <= $tolerance);
-}
-
-/**
  * Sequences a value into a {@see \Generator}.
  *
  * @package Generators

--- a/src/functions.php
+++ b/src/functions.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace empaphy\usephul;
 
+use empaphy\usephul\var\Type;
+
 /**
  * Interchange the values of two elements of an array.
  *

--- a/src/var.php
+++ b/src/var.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace empaphy\usephul\var;
 
-use empaphy\usephul\Type;
-
 /**
  * Default error tolerance.
  */

--- a/src/var.php
+++ b/src/var.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Variable handling Functions.
+ *
+ * @author    Alwin Garside <alwin@garsi.de>
+ * @copyright 2025 The Empaphy Project
+ * @license   MIT
+ * @package   Types\Variables
+ */
+
+declare(strict_types=1);
+
+namespace empaphy\usephul\var;
+
+use empaphy\usephul\Type;
+
+/**
+ * Default error tolerance.
+ */
+const PHP_ZERO_TOLERANCE = 0.00000000001;
+
+/**
+ * Finds whether the given variable is a resource that has been closed.
+ *
+ * @param  mixed  $value
+ *   The variable being evaluated.
+ *
+ * @return ($value is closed-resource ? true : false)
+ *   Returns <u>true</u> if **value** is a <u>resource</u> variable that has
+ *   been closed, <u>false</u> otherwise.
+ */
+function is_closed_resource(mixed $value): bool
+{
+    return Type::ClosedResource->is($value);
+}
+
+/**
+ * Finds whether the given number is (sufficiently close to) 0.
+ *
+ * @param  int|float   $value
+ *   The number being evaluated.
+ *
+ * @param  float|null  $tolerance
+ *   Tolerance allowed when evaluating the number.
+ *
+ * @return bool
+ *   Returns <u>true</u> if **value** is (sufficiently close to) `0`,
+ *   <u>false</u> otherwise.
+ */
+function is_zero(int | float $value, ?float $tolerance = PHP_ZERO_TOLERANCE): bool
+{
+    return 0 === $value || 0.0 === $value || (null !== $tolerance && \abs($value) <= $tolerance);
+}

--- a/src/var.php
+++ b/src/var.php
@@ -34,6 +34,21 @@ function is_closed_resource(mixed $value): bool
 }
 
 /**
+ * Find whether a variable is an integer and less than zero.
+ *
+ * @param  mixed  $value
+ *   The variable being evaluated.
+ *
+ * @return ($value is negative-int ? true : false)
+ *   Returns <u>true</u> if **value** is a negative <u>integer</u>,
+ *   <u>false</u> otherwise.
+ */
+function is_negative_int(mixed $value): bool
+{
+    return \is_int($value) && $value < 0;
+}
+
+/**
  * Find whether a variable is a non-empty string.
  *
  * @param  mixed  $value
@@ -45,6 +60,83 @@ function is_closed_resource(mixed $value): bool
 function is_non_empty_string(mixed $value): bool
 {
     return ! empty($value) && \is_string($value);
+}
+
+/**
+ * Find whether a variable is an integer and not less than zero.
+ *
+ * @param  mixed  $value
+ *   The variable being evaluated.
+ *
+ * @return ($value is non-negative-int ? true : false)
+ *   Returns <u>true</u> if **value** is a non-negative <u>integer</u>,
+ *   <u>false</u> otherwise.
+ */
+function is_non_negative_int(mixed $value): bool
+{
+    return \is_int($value) && $value >= 0;
+}
+
+/**
+ * Find whether a variable is an integer and not greater than zero.
+ *
+ * @param  mixed  $value
+ *   The variable being evaluated.
+ *
+ * @return ($value is non-positive-int ? true : false)
+ *   Returns <u>true</u> if **value** is a non-positive <u>integer</u>,
+ *   <u>false</u> otherwise.
+ */
+function is_non_positive_int(mixed $value): bool
+{
+    return \is_int($value) && $value <= 0;
+}
+
+/**
+ * Find whether a variable is an integer and not zero.
+ *
+ * @param  mixed  $value
+ *   The variable being evaluated.
+ *
+ * @return ($value is non-zero-int ? true : false)
+ *   Returns <u>true</u> if **value** is a non-zero <u>integer</u>, <u>false</u>
+ *   otherwise.
+ *
+ * @noinspection PhpUndefinedClassInspection
+ */
+function is_non_zero_int(mixed $value): bool
+{
+    return \is_int($value) && $value !== 0;
+}
+
+/**
+ * Find whether a variable is a number (either an integer or a float).
+ *
+ * @param  mixed  $value
+ *   The variable being evaluated.
+ *
+ * @return ($value is number ? true : false)
+ *   Returns <u>true</u> if **value** is an <u>integer</u> or a <u>float</u>,
+ *   <u>false</u> otherwise.
+ */
+function is_number(mixed $value): bool
+{
+    return \is_int($value) || \is_float($value);
+}
+
+/**
+ * Find whether a variable is an integer and greater than zero.
+ *
+ * @param  mixed  $value
+ *   The variable being evaluated.
+ *
+ * @return ($value is positive-int ? true : false)
+ *   Returns <u>true</u> if **value** is a positive <u>integer</u>, <u>false</u>
+ *   otherwise.
+ */
+function is_positive_int(mixed $value): bool
+{
+    return \is_int($value) && $value > 0;
 }
 
 /**

--- a/src/var.php
+++ b/src/var.php
@@ -34,6 +34,20 @@ function is_closed_resource(mixed $value): bool
 }
 
 /**
+ * Find whether a variable is a non-empty string.
+ *
+ * @param  mixed  $value
+ *   The variable being evaluated.
+ *
+ * @return ($value is non-empty-string ? true : false)
+ *   Returns <u>true</u> if value is a non-empty string, <u>false</u> otherwise.
+ */
+function is_non_empty_string(mixed $value): bool
+{
+    return ! empty($value) && \is_string($value);
+}
+
+/**
  * Finds whether the given number is (sufficiently close to) 0.
  *
  * @param  int|float   $value

--- a/src/var/Type.php
+++ b/src/var/Type.php
@@ -9,7 +9,7 @@
 
 declare(strict_types=1);
 
-namespace empaphy\usephul;
+namespace empaphy\usephul\var;
 
 use empaphy\usephul\Enumerations\EnumDynamicity;
 

--- a/tests/Datasets/Types.php
+++ b/tests/Datasets/Types.php
@@ -9,7 +9,7 @@
 
 declare(strict_types=1);
 
-use empaphy\usephul\Type;
+use empaphy\usephul\var\Type;
 
 $closedResource = fopen(__FILE__, 'rb');
 fclose($closedResource);

--- a/tests/Unit/FunctionsTest.php
+++ b/tests/Unit/FunctionsTest.php
@@ -54,39 +54,6 @@ describe('array_interchange()', function () {
     ]);
 });
 
-describe('is_closed_resource()', function () {
-    it('correctly returns whether value is a closed resource', function ($value, $type) {
-        $isClosed = usephul\is_closed_resource($value);
-        $expected = usephul\Type::ClosedResource === $type;
-
-        expect($isClosed)->toBe($expected);
-    })->with('types / test cases');
-});
-
-describe('is_zero()', function () {
-    test('returns true if value is (close to) 0', function ($value, $tolerance) {
-        $isZero = usephul\is_zero($value, $tolerance);
-
-        expect($isZero)->toBeTrue();
-    })->with([
-        [0, null],
-        [0.0, null],
-        [PHP_FLOAT_MIN, usephul\PHP_ZERO_TOLERANCE],
-        [PHP_FLOAT_MIN, PHP_FLOAT_MIN],
-    ]);
-
-    test('returns false if value is not (close to) 0', function ($value, $tolerance) {
-        $isZero = usephul\is_zero($value, $tolerance);
-
-        expect($isZero)->toBeFalse();
-    })->with([
-        [1, usephul\PHP_ZERO_TOLERANCE],
-        [1.0, usephul\PHP_ZERO_TOLERANCE],
-        [PHP_FLOAT_EPSILON, PHP_FLOAT_MIN],
-        [PHP_FLOAT_MIN, null],
-    ]);
-});
-
 describe('seq()', function () {
     test('properly sequences values', function ($data, $expected) {
         $array = [];

--- a/tests/Unit/TypeTest.php
+++ b/tests/Unit/TypeTest.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-use empaphy\usephul\Type;
+use empaphy\usephul\var\Type;
 
 describe('Type', function () {
     it('has the appropriate cases', function ($case, $expected) {

--- a/tests/Unit/VarTest.php
+++ b/tests/Unit/VarTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * @author    Alwin Garside <alwin@garsi.de>
+ * @copyright 2025 The Empaphy Project
+ * @license   MIT
+ * @package   empaphy\usephul
+ *
+ * @noinspection StaticClosureCanBeUsedInspection
+ */
+
+declare(strict_types=1);
+
+namespace empaphy\usephul\test\var;
+
+use empaphy\usephul\Type;
+use empaphy\usephul\var;
+
+describe('is_closed_resource()', function () {
+    it('correctly returns whether value is a closed resource', function ($value, $type) {
+        $isClosed = var\is_closed_resource($value);
+        $expected = Type::ClosedResource === $type;
+
+        expect($isClosed)->toBe($expected);
+    })->with('types / test cases');
+});
+
+describe('is_zero()', function () {
+    test('returns true if value is (close to) 0', function ($value, $tolerance) {
+        $isZero = var\is_zero($value, $tolerance);
+
+        expect($isZero)->toBeTrue();
+    })->with([
+        [0, null],
+        [0.0, null],
+        [PHP_FLOAT_MIN, var\PHP_ZERO_TOLERANCE],
+        [PHP_FLOAT_MIN, PHP_FLOAT_MIN],
+    ]);
+
+    test('returns false if value is not (close to) 0', function ($value, $tolerance) {
+        $isZero = var\is_zero($value, $tolerance);
+
+        expect($isZero)->toBeFalse();
+    })->with([
+        [1, var\PHP_ZERO_TOLERANCE],
+        [1.0, var\PHP_ZERO_TOLERANCE],
+        [PHP_FLOAT_EPSILON, PHP_FLOAT_MIN],
+        [PHP_FLOAT_MIN, null],
+    ]);
+});

--- a/tests/Unit/VarTest.php
+++ b/tests/Unit/VarTest.php
@@ -11,15 +11,12 @@
 
 declare(strict_types=1);
 
-namespace empaphy\usephul\test\var;
-
-use empaphy\usephul\Type;
 use empaphy\usephul\var;
 
 describe('is_closed_resource()', function () {
     it('correctly returns whether value is a closed resource', function ($value, $type) {
         $isClosed = var\is_closed_resource($value);
-        $expected = Type::ClosedResource === $type;
+        $expected = var\Type::ClosedResource === $type;
 
         expect($isClosed)->toBe($expected);
     })->with('types / test cases');

--- a/tests/Unit/VarTest.php
+++ b/tests/Unit/VarTest.php
@@ -22,6 +22,28 @@ describe('is_closed_resource()', function () {
     })->with('types / test cases');
 });
 
+describe('is_negative_int()', function () {
+    test('returns true', function ($value) {
+        $result = var\is_negative_int($value);
+
+        expect($result)->toBeTrue();
+    })->with([[-1]]);
+
+    test('returns false', function ($value) {
+        $result = var\is_negative_int($value);
+
+        expect($result)->toBeFalse();
+    })->with([
+        [0],
+        [1],
+        [-0.1],
+        ['-1'],
+        [[-1]],
+        [new stdClass()],
+        [null],
+    ]);
+});
+
 describe('is_non_empty_string()', function() {
     test('returns true', function ($value) {
         $result = var\is_non_empty_string($value);
@@ -36,13 +58,134 @@ describe('is_non_empty_string()', function() {
 
         expect($result)->toBeFalse();
     })->with([
-        [1337],
-        [1.337],
+        [1],
+        [0.1],
         [['foo']],
         [new stdClass()],
         [''],
         [null],
         [[]],
+    ]);
+});
+
+describe('is_number()', function () {
+    test('returns true', function ($value) {
+        $result = var\is_number($value);
+
+        expect($result)->toBeTrue();
+    })->with([
+        [1],
+        [0],
+        [-1],
+        [0.1],
+        [\NAN],
+    ]);
+
+    test('returns false', function ($value) {
+        $result = var\is_number($value);
+
+        expect($result)->toBeFalse();
+    })->with([
+        ['1'],
+        ['0'],
+        ['-1'],
+        [new stdClass()],
+        [null],
+        [[]],
+    ]);
+});
+
+describe('is_non_negative_int()', function () {
+    test('returns true', function ($value) {
+        $result = var\is_non_negative_int($value);
+
+        expect($result)->toBeTrue();
+    })->with([
+        [0],
+        [1],
+    ]);
+
+    test('returns false', function ($value) {
+        $result = var\is_non_negative_int($value);
+
+        expect($result)->toBeFalse();
+    })->with([
+        [-1],
+        [1.0],
+        ['1'],
+        [[1]],
+        [new stdClass()],
+        [null],
+    ]);
+});
+
+describe('is_non_positive_int()', function () {
+    test('returns true', function ($value) {
+        $result = var\is_non_positive_int($value);
+
+        expect($result)->toBeTrue();
+    })->with([
+        [0],
+        [-1],
+    ]);
+
+    test('returns false', function ($value) {
+        $result = var\is_non_positive_int($value);
+
+        expect($result)->toBeFalse();
+    })->with([
+        [1],
+        [-1.0],
+        ['-1'],
+        [[-1]],
+        [new stdClass()],
+        [null],
+    ]);
+});
+
+describe('is_non_zero_int()', function () {
+    test('returns true', function ($value) {
+        $result = var\is_non_zero_int($value);
+
+        expect($result)->toBeTrue();
+    })->with([
+        [1],
+        [-1],
+    ]);
+
+    test('returns false', function ($value) {
+        $result = var\is_non_zero_int($value);
+
+        expect($result)->toBeFalse();
+    })->with([
+        [0],
+        [1.0],
+        ['1'],
+        [[1]],
+        [new stdClass()],
+        [null],
+    ]);
+});
+
+describe('is_positive_int()', function () {
+    test('returns true', function ($value) {
+        $result = var\is_positive_int($value);
+
+        expect($result)->toBeTrue();
+    })->with([[1]]);
+
+    test('returns false', function ($value) {
+        $result = var\is_positive_int($value);
+
+        expect($result)->toBeFalse();
+    })->with([
+        [0],
+        [-1],
+        [0.1],
+        ['1'],
+        [[1]],
+        [new stdClass()],
+        [null],
     ]);
 });
 

--- a/tests/Unit/VarTest.php
+++ b/tests/Unit/VarTest.php
@@ -22,6 +22,30 @@ describe('is_closed_resource()', function () {
     })->with('types / test cases');
 });
 
+describe('is_non_empty_string()', function() {
+    test('returns true', function ($value) {
+        $result = var\is_non_empty_string($value);
+
+        expect($result)->toBeTrue();
+    })->with([
+        ['foo']
+    ]);
+
+    test('returns false', function ($value) {
+        $result = var\is_non_empty_string($value);
+
+        expect($result)->toBeFalse();
+    })->with([
+        [1337],
+        [1.337],
+        [['foo']],
+        [new stdClass()],
+        [''],
+        [null],
+        [[]],
+    ]);
+});
+
 describe('is_zero()', function () {
     test('returns true if value is (close to) 0', function ($value, $tolerance) {
         $isZero = var\is_zero($value, $tolerance);


### PR DESCRIPTION
- fix: move var functions to separate file & namespace
  
  BREAKING CHANGE: this changes the namespace of `is_closed_resource()` and `is_zero()`

- fix: move Type class to empaphy\usephul\var namespace
  
  BREAKING CHANGE: this changes the namespace of `Type`

- feat: function added: is_non_empty_string()

- feat: functions added:

  - `is_negative_int()`
  - `is_non_negative_int()`
  - `is_non_positive_int()`
  - `is_non_zero_int()`
  - `is_number()`
  - `is_positive_int()`